### PR TITLE
Remove all tags from records

### DIFF
--- a/src/app/accounts/[id]/page.tsx
+++ b/src/app/accounts/[id]/page.tsx
@@ -83,15 +83,6 @@ export default function AccountDetailPage({ params }: { params: Promise<{ id: st
               </div>
               <div className="flex flex-wrap gap-2">
                 {account.industry && <Badge variant="outline" className="text-sm">{account.industry}</Badge>}
-                {account.tags.map(tag => (
-                  <Badge
-                    key={tag.id}
-                    variant="outline"
-                    style={{ borderColor: tag.color, color: tag.color }}
-                  >
-                    {tag.name}
-                  </Badge>
-                ))}
               </div>
             </div>
           </CardHeader>

--- a/src/app/accounts/new/page.tsx
+++ b/src/app/accounts/new/page.tsx
@@ -4,17 +4,14 @@ import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
 import { accountsStore } from "@/lib/store/accounts"
 import { AccountStatus, AccountIndustry } from "@/types/account"
-import { Tag } from "@/types/deal"
 import { ArrowLeft, Save } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
 export default function NewAccountPage() {
   const router = useRouter()
-  const allTags = accountsStore.getTags()
 
   const [formData, setFormData] = useState({
     name: "",
@@ -30,7 +27,6 @@ export default function NewAccountPage() {
     status: "活動中" as AccountStatus,
     description: "",
     notes: "",
-    selectedTags: [] as Tag[],
   })
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -53,21 +49,11 @@ export default function NewAccountPage() {
       annualRevenue: formData.annualRevenue ? Number(formData.annualRevenue) : undefined,
       address: formData.address || undefined,
       status: formData.status,
-      tags: formData.selectedTags,
       description: formData.description || undefined,
       notes: formData.notes || undefined,
     })
 
     router.push("/accounts")
-  }
-
-  const toggleTag = (tag: Tag) => {
-    setFormData(prev => ({
-      ...prev,
-      selectedTags: prev.selectedTags.find(t => t.id === tag.id)
-        ? prev.selectedTags.filter(t => t.id !== tag.id)
-        : [...prev.selectedTags, tag]
-    }))
   }
 
   return (
@@ -267,32 +253,6 @@ export default function NewAccountPage() {
                   placeholder="メモや特記事項を入力してください"
                   className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* タグ */}
-          <Card>
-            <CardHeader>
-              <CardTitle>タグ</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-wrap gap-2">
-                {allTags.map(tag => (
-                  <Badge
-                    key={tag.id}
-                    variant={formData.selectedTags.find(t => t.id === tag.id) ? "default" : "outline"}
-                    className="cursor-pointer"
-                    onClick={() => toggleTag(tag)}
-                    style={
-                      formData.selectedTags.find(t => t.id === tag.id)
-                        ? { backgroundColor: tag.color, borderColor: tag.color }
-                        : { borderColor: tag.color, color: tag.color }
-                    }
-                  >
-                    {tag.name}
-                  </Badge>
-                ))}
               </div>
             </CardContent>
           </Card>

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -146,22 +146,6 @@ export default function AccountsPage() {
                     )}
                   </div>
 
-                  {/* タグ */}
-                  {account.tags.length > 0 && (
-                    <div className="flex gap-2 flex-wrap">
-                      {account.tags.map(tag => (
-                        <Badge
-                          key={tag.id}
-                          variant="outline"
-                          className="text-xs"
-                          style={{ borderColor: tag.color, color: tag.color }}
-                        >
-                          {tag.name}
-                        </Badge>
-                      ))}
-                    </div>
-                  )}
-
                   {/* メタ情報 */}
                   <div className="flex gap-4 text-xs text-muted-foreground">
                     {account.representative && <span>代表: {account.representative}</span>}

--- a/src/app/deals/[id]/page.tsx
+++ b/src/app/deals/[id]/page.tsx
@@ -72,15 +72,6 @@ export default function DealDetailPage({ params }: { params: Promise<{ id: strin
               </div>
               <div className="flex flex-wrap gap-2">
                 <Badge variant="outline" className="text-sm">{deal.status}</Badge>
-                {deal.tags.map(tag => (
-                  <Badge
-                    key={tag.id}
-                    variant="outline"
-                    style={{ borderColor: tag.color, color: tag.color }}
-                  >
-                    {tag.name}
-                  </Badge>
-                ))}
               </div>
             </div>
           </CardHeader>

--- a/src/app/deals/new/page.tsx
+++ b/src/app/deals/new/page.tsx
@@ -4,16 +4,14 @@ import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
 import { dealsStore } from "@/lib/store/deals"
-import { DealStatus, DealPriority, Tag } from "@/types/deal"
+import { DealStatus, DealPriority } from "@/types/deal"
 import { ArrowLeft, Save } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
 export default function NewDealPage() {
   const router = useRouter()
-  const allTags = dealsStore.getTags()
 
   const [formData, setFormData] = useState({
     title: "",
@@ -31,7 +29,6 @@ export default function NewDealPage() {
     product: "",
     team: "",
     notes: "",
-    selectedTags: [] as Tag[],
   })
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -53,7 +50,6 @@ export default function NewDealPage() {
       priority: formData.priority,
       probability: Number(formData.probability) || 0,
       expectedCloseDate: formData.expectedCloseDate || new Date().toISOString().split('T')[0],
-      tags: formData.selectedTags,
       description: formData.description || undefined,
       area: formData.area || undefined,
       product: formData.product || undefined,
@@ -62,15 +58,6 @@ export default function NewDealPage() {
     })
 
     router.push("/deals")
-  }
-
-  const toggleTag = (tag: Tag) => {
-    setFormData(prev => ({
-      ...prev,
-      selectedTags: prev.selectedTags.find(t => t.id === tag.id)
-        ? prev.selectedTags.filter(t => t.id !== tag.id)
-        : [...prev.selectedTags, tag]
-    }))
   }
 
   return (
@@ -283,32 +270,6 @@ export default function NewDealPage() {
                   placeholder="メモや特記事項を入力してください"
                   className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* タグ */}
-          <Card>
-            <CardHeader>
-              <CardTitle>タグ</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-wrap gap-2">
-                {allTags.map(tag => (
-                  <Badge
-                    key={tag.id}
-                    variant={formData.selectedTags.find(t => t.id === tag.id) ? "default" : "outline"}
-                    className="cursor-pointer"
-                    onClick={() => toggleTag(tag)}
-                    style={
-                      formData.selectedTags.find(t => t.id === tag.id)
-                        ? { backgroundColor: tag.color, borderColor: tag.color }
-                        : { borderColor: tag.color, color: tag.color }
-                    }
-                  >
-                    {tag.name}
-                  </Badge>
-                ))}
               </div>
             </CardContent>
           </Card>

--- a/src/app/deals/page.tsx
+++ b/src/app/deals/page.tsx
@@ -138,22 +138,6 @@ export default function DealsPage() {
                     </span>
                   </div>
 
-                  {/* タグ */}
-                  {deal.tags.length > 0 && (
-                    <div className="flex gap-2 flex-wrap">
-                      {deal.tags.map(tag => (
-                        <Badge
-                          key={tag.id}
-                          variant="outline"
-                          className="text-xs"
-                          style={{ borderColor: tag.color, color: tag.color }}
-                        >
-                          {tag.name}
-                        </Badge>
-                      ))}
-                    </div>
-                  )}
-
                   {/* メタ情報 */}
                   <div className="flex gap-4 text-xs text-muted-foreground">
                     {deal.area && <span>📍 {deal.area}</span>}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -100,13 +100,6 @@ export default function Home() {
                       </Badge>
                     </div>
                     <p className="text-sm text-muted-foreground">{deal.company}</p>
-                    <div className="flex gap-2 flex-wrap">
-                      {deal.tags.map(tag => (
-                        <Badge key={tag.id} variant="outline" className="text-xs" style={{ borderColor: tag.color }}>
-                          {tag.name}
-                        </Badge>
-                      ))}
-                    </div>
                   </div>
                   <div className="text-right">
                     <p className="font-semibold">¥{(deal.amount / 10000).toFixed(0)}万</p>

--- a/src/app/reports/builder/page.tsx
+++ b/src/app/reports/builder/page.tsx
@@ -209,7 +209,6 @@ export default function ReportBuilderPage() {
     { field: "contactPerson", label: "担当者", description: "顧客担当者別" },
     { field: "createdAt", label: "作成日", description: "案件作成日別" },
     { field: "updatedAt", label: "更新日", description: "案件更新日別" },
-    { field: "tags", label: "タグ", description: "タグ別の分類" },
   ]
 
   const availableMetrics: { type: MetricType; field: MetricField; label: string; description: string }[] = [

--- a/src/app/reports/builder/page.tsx
+++ b/src/app/reports/builder/page.tsx
@@ -170,7 +170,6 @@ export default function ReportBuilderPage() {
   const allAreas = dealsStore.getAreas()
   const allProducts = dealsStore.getProducts()
   const allTeams = dealsStore.getTeams()
-  const allTags = dealsStore.getTags()
 
   const steps: { key: Step; label: string; number: number }[] = [
     { key: "chart", label: "グラフ", number: 1 },

--- a/src/lib/store/accounts.ts
+++ b/src/lib/store/accounts.ts
@@ -1,15 +1,6 @@
 "use client"
 
 import { Account, AccountFilterCondition, AccountStatus, AccountIndustry } from "@/types/account"
-import { Tag } from "@/types/deal"
-
-// モックタグ
-const mockTags: Tag[] = [
-  { id: "1", name: "重要", color: "#ef4444" },
-  { id: "2", name: "至急", color: "#f59e0b" },
-  { id: "3", name: "大口", color: "#8b5cf6" },
-  { id: "4", name: "既存顧客", color: "#3b82f6" },
-]
 
 // モックアカウントデータ（商談データに基づく会社）
 const mockAccounts: Account[] = [
@@ -28,7 +19,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-01-15",
     updatedAt: "2025-11-15",
-    tags: [mockTags[0], mockTags[3]],
     description: "ITソリューション提供企業",
     notes: "長期取引先、決裁が早い"
   },
@@ -47,7 +37,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-02-01",
     updatedAt: "2025-11-10",
-    tags: [mockTags[3]],
     description: "デジタルマーケティング支援",
   },
   {
@@ -65,7 +54,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-03-01",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[2]],
     description: "国際貿易・物流サービス",
     notes: "大型案件の可能性あり"
   },
@@ -84,7 +72,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-01-20",
     updatedAt: "2025-11-16",
-    tags: [mockTags[0], mockTags[2]],
     description: "電機製品製造メーカー",
   },
   {
@@ -102,7 +89,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-04-01",
     updatedAt: "2025-11-14",
-    tags: [mockTags[3]],
     description: "食品販売・EC事業",
   },
   {
@@ -120,7 +106,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-02-15",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[2]],
     description: "物流・倉庫サービス",
     notes: "契約間近"
   },
@@ -139,7 +124,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-05-01",
     updatedAt: "2025-11-15",
-    tags: [mockTags[0]],
     description: "農業IoT・スマート農業",
   },
   {
@@ -157,7 +141,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-03-15",
     updatedAt: "2025-10-31",
-    tags: [mockTags[3]],
     description: "地域観光振興",
   },
   {
@@ -175,7 +158,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-01-10",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[2]],
     description: "重工業・機械製造",
     notes: "大型DX案件検討中"
   },
@@ -194,7 +176,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-04-15",
     updatedAt: "2025-11-16",
-    tags: [mockTags[3]],
     description: "物流倉庫・配送サービス",
   },
   {
@@ -212,7 +193,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-02-20",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0]],
     description: "観光事業・旅行サービス",
     notes: "インバウンド需要増加中"
   },
@@ -231,7 +211,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-01-05",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[2]],
     description: "地方銀行",
     notes: "CRM刷新案件が進行中"
   },
@@ -250,7 +229,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-03-10",
     updatedAt: "2025-11-15",
-    tags: [mockTags[0], mockTags[2]],
     description: "自動車部品製造",
   },
   {
@@ -268,7 +246,6 @@ const mockAccounts: Account[] = [
     status: "活動中",
     createdAt: "2025-04-01",
     updatedAt: "2025-11-16",
-    tags: [mockTags[0], mockTags[2]],
     description: "港湾物流・コンテナ輸送",
   },
   {
@@ -283,7 +260,6 @@ const mockAccounts: Account[] = [
     status: "休止",
     createdAt: "2024-01-01",
     updatedAt: "2024-06-01",
-    tags: [],
     description: "テスト用休止アカウント",
   },
 ]
@@ -314,7 +290,6 @@ const mockFilterConditions: AccountFilterCondition[] = [
 class AccountsStore {
   private accounts: Account[] = mockAccounts
   private filterConditions: AccountFilterCondition[] = mockFilterConditions
-  private tags: Tag[] = mockTags
 
   getAccounts(): Account[] {
     return this.accounts
@@ -368,10 +343,6 @@ class AccountsStore {
     return newCondition
   }
 
-  getTags(): Tag[] {
-    return this.tags
-  }
-
   filterAccounts(condition: AccountFilterCondition): Account[] {
     let filtered = [...this.accounts]
 
@@ -392,11 +363,6 @@ class AccountsStore {
     }
     if (filters.maxRevenue !== undefined) {
       filtered = filtered.filter(account => account.annualRevenue && account.annualRevenue <= filters.maxRevenue!)
-    }
-    if (filters.tags && filters.tags.length > 0) {
-      filtered = filtered.filter(account =>
-        account.tags.some(tag => filters.tags!.includes(tag.id))
-      )
     }
 
     // ソート

--- a/src/lib/store/deals.ts
+++ b/src/lib/store/deals.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { Deal, FilterCondition, Tag, CustomReport, CustomReportConfig, AdvancedFilter, MetricDefinition, ReportDataPoint, DimensionField, DealStatus, DealPriority } from "@/types/deal"
+import { Deal, FilterCondition, CustomReport, CustomReportConfig, AdvancedFilter, MetricDefinition, ReportDataPoint, DimensionField, DealStatus, DealPriority } from "@/types/deal"
 import { evaluateFormula, evaluateCalculatedFields } from "@/lib/formula-parser"
 
 // ディメンションの全ての可能な値を定義
@@ -36,13 +36,6 @@ function generateMonthRange(startDate?: string, endDate?: string, existingMonths
 }
 
 // モックデータ
-const mockTags: Tag[] = [
-  { id: "1", name: "重要", color: "#ef4444" },
-  { id: "2", name: "至急", color: "#f59e0b" },
-  { id: "3", name: "大口", color: "#8b5cf6" },
-  { id: "4", name: "既存顧客", color: "#3b82f6" },
-]
-
 const mockDeals: Deal[] = [
   // 関東エリア
   {
@@ -59,7 +52,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-12-15",
     createdAt: "2025-10-01",
     updatedAt: "2025-11-15",
-    tags: [mockTags[0], mockTags[2]],
     description: "既存システムの老朽化に伴うCRM刷新案件",
     area: "関東",
     product: "CRMシステム",
@@ -80,7 +72,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-12-30",
     createdAt: "2025-10-15",
     updatedAt: "2025-11-10",
-    tags: [mockTags[3]],
     description: "コーポレートサイトの全面リニューアル",
     area: "関東",
     product: "Webサイト制作",
@@ -100,7 +91,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-01-31",
     createdAt: "2025-11-01",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[1], mockTags[2]],
     description: "AWS移行とマイクロサービス化",
     area: "関東",
     product: "クラウドサービス",
@@ -122,7 +112,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-01-15",
     createdAt: "2025-10-20",
     updatedAt: "2025-11-16",
-    tags: [mockTags[0], mockTags[2]],
     description: "工場向けセキュリティ監視システムの導入",
     area: "関西",
     product: "セキュリティソリューション",
@@ -143,7 +132,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-12-20",
     createdAt: "2025-10-25",
     updatedAt: "2025-11-14",
-    tags: [mockTags[3]],
     description: "食品ECサイトの新規構築",
     area: "関西",
     product: "Webサイト制作",
@@ -163,7 +151,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-11-30",
     createdAt: "2025-09-15",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[1], mockTags[2]],
     description: "物流データの可視化と予測分析",
     area: "関西",
     product: "データ分析基盤",
@@ -185,7 +172,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-02-15",
     createdAt: "2025-10-10",
     updatedAt: "2025-11-15",
-    tags: [mockTags[0]],
     description: "スマート農業向けIoTセンサーシステム",
     area: "東北",
     product: "クラウドサービス",
@@ -206,7 +192,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-10-31",
     createdAt: "2025-08-01",
     updatedAt: "2025-10-31",
-    tags: [mockTags[3]],
     description: "地域観光ガイドアプリの開発",
     area: "東北",
     product: "モバイルアプリ開発",
@@ -227,7 +212,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-03-31",
     createdAt: "2025-11-05",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[2]],
     description: "製造ラインのデジタル化推進",
     area: "九州",
     product: "データ分析基盤",
@@ -248,7 +232,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-01-20",
     createdAt: "2025-10-28",
     updatedAt: "2025-11-16",
-    tags: [mockTags[3]],
     description: "倉庫在庫のリアルタイム管理",
     area: "九州",
     product: "CRMシステム",
@@ -268,7 +251,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-02-28",
     createdAt: "2025-10-15",
     updatedAt: "2025-11-15",
-    tags: [mockTags[0], mockTags[2]],
     description: "グループ社内ポータルサイトの統合・刷新",
     area: "九州",
     product: "Webサイト制作",
@@ -289,7 +271,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-12-10",
     createdAt: "2025-09-20",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[1]],
     description: "インバウンド向け予約プラットフォーム",
     area: "北海道",
     product: "Webサイト制作",
@@ -310,7 +291,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-02-28",
     createdAt: "2025-10-30",
     updatedAt: "2025-11-16",
-    tags: [mockTags[2]],
     description: "酪農家向けデータ管理クラウドシステム",
     area: "北海道",
     product: "クラウドサービス",
@@ -331,7 +311,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-01-31",
     createdAt: "2025-10-05",
     updatedAt: "2025-11-15",
-    tags: [mockTags[0], mockTags[2]],
     description: "部品在庫・発注の自動化システム",
     area: "中部",
     product: "CRMシステム",
@@ -352,7 +331,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-06-30",
     createdAt: "2025-11-10",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[1], mockTags[2]],
     description: "製造工程の完全自動化・IoT化",
     area: "中部",
     product: "データ分析基盤",
@@ -373,7 +351,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-11-15",
     createdAt: "2025-09-01",
     updatedAt: "2025-11-15",
-    tags: [mockTags[3]],
     description: "現場作業員向け勤怠管理アプリ",
     area: "中部",
     product: "モバイルアプリ開発",
@@ -394,7 +371,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-02-15",
     createdAt: "2025-10-12",
     updatedAt: "2025-11-16",
-    tags: [mockTags[0], mockTags[2]],
     description: "港湾コンテナ管理の最適化システム",
     area: "中国",
     product: "データ分析基盤",
@@ -415,7 +391,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-01-31",
     createdAt: "2025-10-22",
     updatedAt: "2025-11-15",
-    tags: [mockTags[0]],
     description: "医療情報セキュリティ強化",
     area: "中国",
     product: "セキュリティソリューション",
@@ -436,7 +411,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-12-20",
     createdAt: "2025-08-15",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0], mockTags[1], mockTags[2]],
     description: "顧客管理・営業支援システムの刷新",
     area: "四国",
     product: "CRMシステム",
@@ -457,7 +431,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-03-31",
     createdAt: "2025-11-12",
     updatedAt: "2025-11-17",
-    tags: [],
     description: "農産物の生産履歴管理システム",
     area: "四国",
     product: "クラウドサービス",
@@ -479,7 +452,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-10-31",
     createdAt: "2025-07-01",
     updatedAt: "2025-10-31",
-    tags: [],
     description: "人事管理システムの提案",
     area: "関東",
     product: "CRMシステム",
@@ -500,7 +472,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-11-20",
     createdAt: "2025-08-20",
     updatedAt: "2025-11-20",
-    tags: [mockTags[0], mockTags[3]],
     description: "不動産営業担当者向けモバイルアプリ",
     area: "関西",
     product: "モバイルアプリ開発",
@@ -520,7 +491,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-03-15",
     createdAt: "2025-11-08",
     updatedAt: "2025-11-17",
-    tags: [mockTags[0]],
     description: "コールセンター業務効率化システム",
     area: "東北",
     product: "CRMシステム",
@@ -540,7 +510,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2025-10-15",
     createdAt: "2025-09-01",
     updatedAt: "2025-10-15",
-    tags: [mockTags[3]],
     description: "既存システムとWeb会議ツールの連携",
     area: "北海道",
     product: "クラウドサービス",
@@ -560,7 +529,6 @@ const mockDeals: Deal[] = [
     expectedCloseDate: "2026-04-30",
     createdAt: "2025-10-18",
     updatedAt: "2025-11-16",
-    tags: [mockTags[0], mockTags[2]],
     description: "医薬品サプライチェーンの可視化・最適化",
     area: "九州",
     product: "データ分析基盤",
@@ -627,7 +595,6 @@ const mockCustomReports: CustomReport[] = [
 class DealsStore {
   private deals: Deal[] = mockDeals
   private filterConditions: FilterCondition[] = mockFilterConditions
-  private tags: Tag[] = mockTags
   private customReports: CustomReport[] = mockCustomReports
 
   getDeals(): Deal[] {
@@ -682,10 +649,6 @@ class DealsStore {
     return newCondition
   }
 
-  getTags(): Tag[] {
-    return this.tags
-  }
-
   filterDeals(condition: FilterCondition): Deal[] {
     let filtered = [...this.deals]
 
@@ -712,11 +675,6 @@ class DealsStore {
     }
     if (filters.team && filters.team.length > 0) {
       filtered = filtered.filter(deal => deal.team && filters.team!.includes(deal.team))
-    }
-    if (filters.tags && filters.tags.length > 0) {
-      filtered = filtered.filter(deal =>
-        deal.tags.some(tag => filters.tags!.includes(tag.id))
-      )
     }
 
     // ソート
@@ -1026,11 +984,6 @@ class DealsStore {
     if (filters.team && filters.team.length > 0) {
       filtered = filtered.filter(deal => deal.team && filters.team!.includes(deal.team))
     }
-    if (filters.tags && filters.tags.length > 0) {
-      filtered = filtered.filter(deal =>
-        deal.tags.some(tag => filters.tags!.includes(tag.id))
-      )
-    }
     if (filters.dateRange?.start) {
       filtered = filtered.filter(deal => deal.expectedCloseDate >= filters.dateRange!.start!)
     }
@@ -1149,8 +1102,6 @@ class DealsStore {
         return deal.createdAt.substring(0, 10)
       case 'updatedAt':
         return deal.updatedAt.substring(0, 10)
-      case 'tags':
-        return deal.tags.length > 0 ? deal.tags.map(t => t.name).join(', ') : 'タグなし'
       default:
         return 'その他'
     }

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -1,5 +1,3 @@
-import { Tag } from "./deal"
-
 export type AccountStatus = "活動中" | "休止" | "見込み" | "提携"
 
 export type AccountIndustry = "IT" | "製造" | "金融" | "物流" | "医療" | "建設" | "農業" | "観光" | "小売" | "その他"
@@ -19,7 +17,6 @@ export interface Account {
   status: AccountStatus
   createdAt: string
   updatedAt: string
-  tags: Tag[]
   description?: string
   notes?: string
 }
@@ -33,7 +30,6 @@ export interface AccountFilterCondition {
     region?: string[]
     minRevenue?: number
     maxRevenue?: number
-    tags?: string[]
   }
   sortBy?: keyof Account
   sortOrder?: "asc" | "desc"

--- a/src/types/deal.ts
+++ b/src/types/deal.ts
@@ -2,12 +2,6 @@ export type DealStatus = "新規" | "アプローチ中" | "提案" | "商談中
 
 export type DealPriority = "高" | "中" | "低"
 
-export interface Tag {
-  id: string
-  name: string
-  color: string
-}
-
 export interface Deal {
   id: string
   title: string
@@ -22,7 +16,6 @@ export interface Deal {
   expectedCloseDate: string
   createdAt: string
   updatedAt: string
-  tags: Tag[]
   description?: string
   area?: string
   product?: string
@@ -41,7 +34,6 @@ export interface FilterCondition {
     area?: string[]
     product?: string[]
     team?: string[]
-    tags?: string[]
   }
   sortBy?: keyof Deal
   sortOrder?: "asc" | "desc"
@@ -66,7 +58,7 @@ export interface Trigger {
 export type ChartType = "bar" | "pie" | "line" | "area" | "scatter" | "radar" | "funnel" | "stackedBar" | "stackedArea" | "table"
 
 // Extended dimension field to include all Deal fields
-export type DimensionField = "status" | "area" | "product" | "team" | "priority" | "month" | "quarter" | "year" | "company" | "contactPerson" | "expectedCloseDate" | "createdAt" | "updatedAt" | "tags"
+export type DimensionField = "status" | "area" | "product" | "team" | "priority" | "month" | "quarter" | "year" | "company" | "contactPerson" | "expectedCloseDate" | "createdAt" | "updatedAt"
 
 export type MetricType = "count" | "sum" | "average" | "min" | "max" | "custom"
 
@@ -120,7 +112,6 @@ export interface CustomReportConfig {
     area?: string[]
     product?: string[]
     team?: string[]
-    tags?: string[]
     dateRange?: {
       start?: string
       end?: string


### PR DESCRIPTION
タグ機能がUIで目障りだったため、全てのタグ関連のコードを削除しました。

変更内容:
- 型定義からTagインターフェースとtags プロパティを削除
- Deal、Account型からtagsフィールドを削除
- FilterCondition、AccountFilterConditionからtagsフィルタを削除
- DimensionFieldからtagsディメンションを削除
- ストアからmockTags、tagsプロパティ、getTags()メソッドを削除
- フィルタリングとレポート生成のタグロジックを削除
- 全UIページからタグ表示・編集UIを削除
- レポートビルダーからタグディメンションオプションを削除